### PR TITLE
Update commands, allow command word synonyms

### DIFF
--- a/src/main/java/seedu/tarence/logic/commands/AddStudentCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/AddStudentCommand.java
@@ -14,11 +14,7 @@ import seedu.tarence.model.person.Person;
 public class AddStudentCommand extends Command {
 
     public static final String COMMAND_WORD = "addStudent";
-    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase(),
-                                                      "addstu", "addstud"};
 
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists!";
-    public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person into T.A.rence. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
@@ -26,6 +22,12 @@ public class AddStudentCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_EMAIL + "johnd@example.com ";
+
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists!";
+    public static final String MESSAGE_SUCCESS = "New person added: %1$s";
+
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase(),
+        "addstu", "addstud"};
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/tarence/logic/commands/AddStudentCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/AddStudentCommand.java
@@ -14,7 +14,11 @@ import seedu.tarence.model.person.Person;
 public class AddStudentCommand extends Command {
 
     public static final String COMMAND_WORD = "addStudent";
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase(),
+                                                      "addstu", "addstud"};
 
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists!";
+    public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person into T.A.rence. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
@@ -22,9 +26,6 @@ public class AddStudentCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_EMAIL + "johnd@example.com ";
-
-    public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists!";
 
     private final Person toAdd;
 
@@ -46,6 +47,21 @@ public class AddStudentCommand extends Command {
 
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    /**
+     * Returns true if user command matches command word or any defined synonyms, and false otherwise.
+     *
+     * @param userCommand command word from user.
+     * @return whether user command matches specified command word or synonyms.
+     */
+    public static boolean isMatchingCommandWord(String userCommand) {
+        for (String synonym : COMMAND_SYNONYMS) {
+            if (synonym.equals(userCommand.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/tarence/logic/commands/DeleteStudentCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/DeleteStudentCommand.java
@@ -13,20 +13,22 @@ import seedu.tarence.model.person.Person;
 /**
  * Deletes a person identified using it's displayed index from T.A.rence.
  */
-public class DeleteCommand extends Command {
+public class DeleteStudentCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_WORD = "deleteStudent";
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase(),
+        "deletestu", "deletestud", "delstudent", "delstu", "delstud"};
+
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
-
     private final Index targetIndex;
 
-    public DeleteCommand(Index targetIndex) {
+    public DeleteStudentCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
@@ -44,10 +46,25 @@ public class DeleteCommand extends Command {
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 
+    /**
+     * Returns true if user command matches command word or any defined synonyms, and false otherwise.
+     *
+     * @param userCommand command word from user.
+     * @return whether user command matches specified command word or synonyms.
+     */
+    public static boolean isMatchingCommandWord(String userCommand) {
+        for (String synonym : COMMAND_SYNONYMS) {
+            if (synonym.equals(userCommand.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof DeleteCommand // instanceof handles nulls
-                && targetIndex.equals(((DeleteCommand) other).targetIndex)); // state check
+                || (other instanceof DeleteStudentCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteStudentCommand) other).targetIndex)); // state check
     }
 }

--- a/src/main/java/seedu/tarence/logic/commands/DeleteStudentCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/DeleteStudentCommand.java
@@ -16,8 +16,6 @@ import seedu.tarence.model.person.Person;
 public class DeleteStudentCommand extends Command {
 
     public static final String COMMAND_WORD = "deleteStudent";
-    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase(),
-        "deletestu", "deletestud", "delstudent", "delstu", "delstud"};
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
@@ -25,6 +23,9 @@ public class DeleteStudentCommand extends Command {
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
+
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase(),
+        "deletestu", "deletestud", "delstudent", "delstu", "delstud"};
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/tarence/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/EditCommand.java
@@ -22,6 +22,7 @@ import seedu.tarence.model.person.Person;
 public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase()};
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
@@ -32,9 +33,9 @@ public class EditCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists.";
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -83,6 +84,21 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
 
         return new Person(updatedName, updatedEmail);
+    }
+
+    /**
+     * Returns true if user command matches command word or any defined synonyms, and false otherwise.
+     *
+     * @param userCommand command word from user.
+     * @return whether user command matches specified command word or synonyms.
+     */
+    public static boolean isMatchingCommandWord(String userCommand) {
+        for (String synonym : COMMAND_SYNONYMS) {
+            if (synonym.equals(userCommand.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/tarence/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/EditCommand.java
@@ -22,7 +22,6 @@ import seedu.tarence.model.person.Person;
 public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
-    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase()};
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
@@ -36,6 +35,8 @@ public class EditCommand extends Command {
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists.";
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase()};
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/tarence/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/ExitCommand.java
@@ -8,12 +8,28 @@ import seedu.tarence.model.Model;
 public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase()};
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting T.A.rence as requested ...";
 
     @Override
     public CommandResult execute(Model model) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+    }
+
+    /**
+     * Returns true if user command matches command word or any defined synonyms, and false otherwise.
+     *
+     * @param userCommand command word from user.
+     * @return whether user command matches specified command word or synonyms.
+     */
+    public static boolean isMatchingCommandWord(String userCommand) {
+        for (String synonym : COMMAND_SYNONYMS) {
+            if (synonym.equals(userCommand.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/src/main/java/seedu/tarence/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/ExitCommand.java
@@ -8,9 +8,10 @@ import seedu.tarence.model.Model;
 public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
-    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase()};
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting T.A.rence as requested ...";
+
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase()};
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/tarence/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/FindCommand.java
@@ -13,6 +13,7 @@ import seedu.tarence.model.person.NameContainsKeywordsPredicate;
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase()};
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
@@ -31,6 +32,21 @@ public class FindCommand extends Command {
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    /**
+     * Returns true if user command matches command word or any defined synonyms, and false otherwise.
+     *
+     * @param userCommand command word from user.
+     * @return whether user command matches specified command word or synonyms.
+     */
+    public static boolean isMatchingCommandWord(String userCommand) {
+        for (String synonym : COMMAND_SYNONYMS) {
+            if (synonym.equals(userCommand.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/tarence/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/HelpCommand.java
@@ -8,6 +8,7 @@ import seedu.tarence.model.Model;
 public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase()};
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
@@ -17,5 +18,20 @@ public class HelpCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+    }
+
+    /**
+     * Returns true if user command matches command word or any defined synonyms, and false otherwise.
+     *
+     * @param userCommand command word from user.
+     * @return whether user command matches specified command word or synonyms.
+     */
+    public static boolean isMatchingCommandWord(String userCommand) {
+        for (String synonym : COMMAND_SYNONYMS) {
+            if (synonym.equals(userCommand.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/seedu/tarence/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/HelpCommand.java
@@ -8,12 +8,13 @@ import seedu.tarence.model.Model;
 public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
-    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase()};
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase()};
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/tarence/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/ListCommand.java
@@ -10,7 +10,9 @@ import seedu.tarence.model.Model;
  */
 public class ListCommand extends Command {
 
-    public static final String COMMAND_WORD = "list";
+    public static final String COMMAND_WORD = "listStudent";
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase(),
+        "liststu", "liststud"};
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 
@@ -20,5 +22,20 @@ public class ListCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    /**
+     * Returns true if user command matches command word or any defined synonyms, and false otherwise.
+     *
+     * @param userCommand command word from user.
+     * @return whether user command matches specified command word or synonyms.
+     */
+    public static boolean isMatchingCommandWord(String userCommand) {
+        for (String synonym : COMMAND_SYNONYMS) {
+            if (synonym.equals(userCommand.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/seedu/tarence/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/tarence/logic/commands/ListCommand.java
@@ -11,11 +11,11 @@ import seedu.tarence.model.Model;
 public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "listStudent";
-    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase(),
-        "liststu", "liststud"};
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 
+    private static final String[] COMMAND_SYNONYMS = {COMMAND_WORD.toLowerCase(),
+        "liststu", "liststud"};
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/tarence/logic/parser/ApplicationParser.java
+++ b/src/main/java/seedu/tarence/logic/parser/ApplicationParser.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 
 import seedu.tarence.logic.commands.AddStudentCommand;
 import seedu.tarence.logic.commands.Command;
-import seedu.tarence.logic.commands.DeleteCommand;
+import seedu.tarence.logic.commands.DeleteStudentCommand;
 import seedu.tarence.logic.commands.EditCommand;
 import seedu.tarence.logic.commands.ExitCommand;
 import seedu.tarence.logic.commands.FindCommand;
@@ -41,32 +41,25 @@ public class ApplicationParser {
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
-        switch (commandWord) {
 
-        case AddStudentCommand.COMMAND_WORD:
+        if (AddStudentCommand.isMatchingCommandWord(commandWord)) {
             return new AddStudentCommandParser().parse(arguments);
-
-        case EditCommand.COMMAND_WORD:
+        } else if (EditCommand.isMatchingCommandWord(commandWord)) {
             return new EditCommandParser().parse(arguments);
-
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
-
-        case FindCommand.COMMAND_WORD:
+        } else if (DeleteStudentCommand.isMatchingCommandWord(commandWord)) {
+            return new DeleteStudentCommandParser().parse(arguments);
+        } else if (FindCommand.isMatchingCommandWord(commandWord)) {
             return new FindCommandParser().parse(arguments);
-
-        case ListCommand.COMMAND_WORD:
+        } else if (ListCommand.isMatchingCommandWord(commandWord)) {
             return new ListCommand();
-
-        case ExitCommand.COMMAND_WORD:
+        } else if (ExitCommand.isMatchingCommandWord(commandWord)) {
             return new ExitCommand();
-
-        case HelpCommand.COMMAND_WORD:
+        } else if (HelpCommand.isMatchingCommandWord(commandWord)) {
             return new HelpCommand();
-
-        default:
+        } else {
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
+
     }
 
 }

--- a/src/main/java/seedu/tarence/logic/parser/DeleteStudentCommandParser.java
+++ b/src/main/java/seedu/tarence/logic/parser/DeleteStudentCommandParser.java
@@ -3,26 +3,26 @@ package seedu.tarence.logic.parser;
 import static seedu.tarence.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.tarence.commons.core.index.Index;
-import seedu.tarence.logic.commands.DeleteCommand;
+import seedu.tarence.logic.commands.DeleteStudentCommand;
 import seedu.tarence.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
  */
-public class DeleteCommandParser implements Parser<DeleteCommand> {
+public class DeleteStudentCommandParser implements Parser<DeleteStudentCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public DeleteCommand parse(String args) throws ParseException {
+    public DeleteStudentCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            return new DeleteStudentCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteStudentCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/test/java/seedu/tarence/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/tarence/logic/LogicManagerTest.java
@@ -56,7 +56,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
+        String deleteCommand = "deleteStudent 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 

--- a/src/test/java/seedu/tarence/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/tarence/logic/commands/CommandTestUtil.java
@@ -3,7 +3,9 @@ package seedu.tarence.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.tarence.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.tarence.logic.parser.CliSyntax.PREFIX_MATNO;
 import static seedu.tarence.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.tarence.logic.parser.CliSyntax.PREFIX_NUSID;
 import static seedu.tarence.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -28,12 +30,15 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_MATRIC_AMY = "A0123456A";
-    public static final String VALID_MATRIC_BOB = "U0987654X";
+    public static final String VALID_MATRIC_BOB = "a3456789a";
+    public static final String VALID_NUSNET_AMY = "E0123456";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String EMAIL_DESC_AMY = " " + PREFIX_EMAIL + VALID_EMAIL_AMY;
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
+    public static final String MATRIC_DESC_AMY = " " + VALID_MATRIC_AMY;
+    public static final String NUSNET_DESC_AMY = " " + VALID_NUSNET_AMY;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol

--- a/src/test/java/seedu/tarence/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/tarence/logic/commands/CommandTestUtil.java
@@ -3,9 +3,7 @@ package seedu.tarence.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.tarence.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.tarence.logic.parser.CliSyntax.PREFIX_MATNO;
 import static seedu.tarence.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.tarence.logic.parser.CliSyntax.PREFIX_NUSID;
 import static seedu.tarence.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;

--- a/src/test/java/seedu/tarence/logic/commands/DeleteStudentCommandTest.java
+++ b/src/test/java/seedu/tarence/logic/commands/DeleteStudentCommandTest.java
@@ -22,29 +22,29 @@ import seedu.tarence.model.person.Person;
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
  * {@code DeleteCommand}.
  */
-public class DeleteCommandTest {
+public class DeleteStudentCommandTest {
 
     private Model model = new ModelManager(getTypicalApplication(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteStudentCommand deleteStudentCommand = new DeleteStudentCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        String expectedMessage = String.format(DeleteStudentCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
         ModelManager expectedModel = new ModelManager(model.getApplication(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteStudentCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteStudentCommand deleteStudentCommand = new DeleteStudentCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteStudentCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
@@ -52,15 +52,15 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteStudentCommand deleteStudentCommand = new DeleteStudentCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        String expectedMessage = String.format(DeleteStudentCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
         Model expectedModel = new ModelManager(model.getApplication(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
         showNoPerson(expectedModel);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteStudentCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
@@ -71,21 +71,21 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of class list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getApplication().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteStudentCommand deleteStudentCommand = new DeleteStudentCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteStudentCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteStudentCommand deleteFirstCommand = new DeleteStudentCommand(INDEX_FIRST_PERSON);
+        DeleteStudentCommand deleteSecondCommand = new DeleteStudentCommand(INDEX_SECOND_PERSON);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteStudentCommand deleteFirstCommandCopy = new DeleteStudentCommand(INDEX_FIRST_PERSON);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/tarence/logic/parser/AddStudentCommandParserTest.java
+++ b/src/test/java/seedu/tarence/logic/parser/AddStudentCommandParserTest.java
@@ -5,8 +5,10 @@ import static seedu.tarence.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.tarence.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.tarence.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.tarence.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.tarence.logic.commands.CommandTestUtil.MATRIC_DESC_AMY;
 import static seedu.tarence.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.tarence.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.tarence.logic.commands.CommandTestUtil.NUSNET_DESC_AMY;
 import static seedu.tarence.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.tarence.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.tarence.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
@@ -14,6 +16,7 @@ import static seedu.tarence.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.tarence.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.tarence.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.tarence.testutil.TypicalPersons.BOB;
+import static seedu.tarence.testutil.TypicalStudents.AMY;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +24,9 @@ import seedu.tarence.logic.commands.AddStudentCommand;
 import seedu.tarence.model.person.Email;
 import seedu.tarence.model.person.Name;
 import seedu.tarence.model.person.Person;
+import seedu.tarence.model.student.Student;
 import seedu.tarence.testutil.PersonBuilder;
+import seedu.tarence.testutil.StudentBuilder;
 
 public class AddStudentCommandParserTest {
     private AddStudentCommandParser parser = new AddStudentCommandParser();
@@ -41,6 +46,21 @@ public class AddStudentCommandParserTest {
         // multiple emails - last email accepted
         assertParseSuccess(parser, NAME_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB,
                 new AddStudentCommand(expectedPerson));
+    }
+
+    @Test
+    public void parse_withOptionalFields_success() {
+        Student expectedStudent = new StudentBuilder(AMY).build();
+
+        // MatricNum and NusnetID both present
+        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY
+                + MATRIC_DESC_AMY + NUSNET_DESC_AMY,
+                new AddStudentCommand(expectedStudent));
+
+        // random ordering of optional fields
+        assertParseSuccess(parser, MATRIC_DESC_AMY + NAME_DESC_AMY
+                + NUSNET_DESC_AMY + EMAIL_DESC_AMY ,
+                new AddStudentCommand(expectedStudent));
     }
 
     @Test

--- a/src/test/java/seedu/tarence/logic/parser/ApplicationParserTest.java
+++ b/src/test/java/seedu/tarence/logic/parser/ApplicationParserTest.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.tarence.logic.commands.AddStudentCommand;
-import seedu.tarence.logic.commands.DeleteCommand;
+import seedu.tarence.logic.commands.DeleteStudentCommand;
 import seedu.tarence.logic.commands.EditCommand;
 import seedu.tarence.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.tarence.logic.commands.ExitCommand;
@@ -41,9 +41,9 @@ public class ApplicationParserTest {
 
     @Test
     public void parseCommand_delete() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+        DeleteStudentCommand command = (DeleteStudentCommand) parser.parseCommand(
+                DeleteStudentCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new DeleteStudentCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test

--- a/src/test/java/seedu/tarence/logic/parser/DeleteStudentCommandParserTest.java
+++ b/src/test/java/seedu/tarence/logic/parser/DeleteStudentCommandParserTest.java
@@ -7,7 +7,7 @@ import static seedu.tarence.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.tarence.logic.commands.DeleteCommand;
+import seedu.tarence.logic.commands.DeleteStudentCommand;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -16,17 +16,17 @@ import seedu.tarence.logic.commands.DeleteCommand;
  * The path variation for those two cases occur inside the ParserUtil, and
  * therefore should be covered by the ParserUtilTest.
  */
-public class DeleteCommandParserTest {
+public class DeleteStudentCommandParserTest {
 
-    private DeleteCommandParser parser = new DeleteCommandParser();
+    private DeleteStudentCommandParser parser = new DeleteStudentCommandParser();
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new DeleteStudentCommand(INDEX_FIRST_PERSON));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteStudentCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/tarence/logic/parser/DeleteStudentCommandParserTest.java
+++ b/src/test/java/seedu/tarence/logic/parser/DeleteStudentCommandParserTest.java
@@ -27,6 +27,7 @@ public class DeleteStudentCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteStudentCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                                                               DeleteStudentCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/tarence/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/tarence/testutil/TypicalStudents.java
@@ -6,6 +6,7 @@ import static seedu.tarence.logic.commands.CommandTestUtil.VALID_MATRIC_AMY;
 import static seedu.tarence.logic.commands.CommandTestUtil.VALID_MATRIC_BOB;
 import static seedu.tarence.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.tarence.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.tarence.logic.commands.CommandTestUtil.VALID_NUSNET_AMY;
 
 import seedu.tarence.model.student.Student;
 
@@ -46,7 +47,7 @@ public class TypicalStudents {
 
     // Manually added - Student's details found in {@code CommandTestUtil}
     public static final Student AMY = new StudentBuilder().withName(VALID_NAME_AMY).withEmail(VALID_EMAIL_AMY)
-                .withMatricNum(VALID_MATRIC_AMY).build();
+                .withMatricNum(VALID_MATRIC_AMY).withNusnetId(VALID_NUSNET_AMY).build();
     public static final Student BOB = new StudentBuilder().withName(VALID_NAME_BOB).withEmail(VALID_EMAIL_BOB)
                 .withMatricNum(VALID_MATRIC_BOB).build();
 


### PR DESCRIPTION
- `delete` and `list` commands are now `deleteStudent` and `listStudent` respectively
- Case-insensitive and shorthand command words are now accepted as inputs; e.g. `deletestudent` and `delstu` are now recognised as `deleteStudent` commands